### PR TITLE
Add --version Flag to CLI for Version Display

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,18 +21,6 @@ https://github.com/user-attachments/assets/c2ba7d09-83ea-4d10-a825-92c30f28c0bd
 
 ---
 
-## Table of Contents
-
-- [✨ Features](#-features)
-- [📥 Installation](#-installation)
-- [⚙️ Configuration](#️-configuration)
-- [🛠 Usage](#-usage)
-- [🌟 Examples](#-examples)
-- [🚧 Development Status](#-development-status)
-- [🤝 Contributing](#-contributing)
-- [📜 License](#-license)
-- [📧 Contact](#-contact)
-
 ### CLI Options
 
 #### `--version`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ https://github.com/user-attachments/assets/c2ba7d09-83ea-4d10-a825-92c30f28c0bd
 - [📜 License](#-license)
 - [📧 Contact](#-contact)
 
+### CLI Options
+
+#### `--version`
+
+The `--version` flag allows users to check the installed version of the package directly from the terminal.
+
+Current version: `PromptShell v0.1.1`
+
 ## ✨ Features
 
 ### 🚀 Redefine Your Terminal Experience

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ https://github.com/user-attachments/assets/c2ba7d09-83ea-4d10-a825-92c30f28c0bd
 
 ---
 
+## Table of Contents
+
+- [✨ Features](#-features)
+- [📥 Installation](#-installation)
+- [⚙️ Configuration](#️-configuration)
+- [🛠 Usage](#-usage)
+- [🌟 Examples](#-examples)
+- [🚧 Development Status](#-development-status)
+- [🤝 Contributing](#-contributing)
+- [📜 License](#-license)
+- [📧 Contact](#-contact)
+
 ## ✨ Features
 
 ### 🚀 Redefine Your Terminal Experience

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -5,8 +5,29 @@ import os
 from .ansi_support import enable_ansi_support
 from .format_utils import format_text, reset_format, get_terminal_size
 from .setup import setup_wizard, load_config, get_active_model
+from pathlib import Path
+import argparse
+import toml
+
+# Function to get the version from pyproject.toml
+def get_version():
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"  # Adjust path if needed
+    pyproject_data = toml.load(pyproject_path)
+    return pyproject_data["project"]["version"]
 
 def main():
+    # Add argument parsing for CLI flags
+    parser = argparse.ArgumentParser(description="PromptShell CLI")
+    parser.add_argument("--version", action="store_true", help="Show the version of PromptShell")
+    args, unknown = parser.parse_known_args()  # Allow unknown args for the assistant
+
+    # Handle the --version flag
+    if args.version:
+        version = get_version()
+        print(f"PromptShell v{version}")
+        return
+
+    # Load configuration
     config = load_config()
     if not config:
         print("First-time setup required!")

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,26 @@
+import subprocess
+import sys
+
+def test_version_flag():
+    print("Running the command to check the version...")
+
+    result = subprocess.run(
+        [sys.executable, "-m", "promptshell.main", "--version"],
+        capture_output=True,
+        text=True
+    )
+
+    if result.returncode == 0:
+        version_output = result.stdout.strip()
+        if version_output.startswith("PromptShell v"):
+            print(f"Version output is as expected: {version_output}")
+        else:
+            print("Unexpected output:")
+            print(version_output)
+    else:
+        print(f"Command failed with return code: {result.returncode}")
+        if result.stderr:
+            print("Error:", result.stderr)
+
+if __name__ == "__main__":
+    test_version_flag()


### PR DESCRIPTION
This pull request introduces a new --version flag to the PromptShell command-line interface, allowing users to easily check the installed version of the package directly from the terminal.

**Key Features:**

- Users can run promptshell --version to display the current version.
- The output is clean and user-friendly, showing the version in the format: PromptShell v0.1.1.
- This addition enhances user experience by providing quick access to version information.

**Acceptance Criteria:**

- The --version flag is fully functional and integrated into the CLI.
- The version displayed matches the one defined in pyproject.toml.
- A test has been added to validate this behavior in the tests folder.