### PR TITLE
Enhance REPL Usability by Supporting 'exit' Command

### DIFF
--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -32,7 +32,7 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
             if len(prompt) + len(user_input) > columns:
                 print()  # Move to the next line if input is too long
 
-            if user_input.lower() == 'quit':
+            if user_input.lower() in ['quit', 'exit']: # Allow both 'quit' and 'exit' commands to terminate the REPL session
                 print(format_text('red', bold=True) + "\nTerminating..." + reset_format())
                 break
 

--- a/tests/test_repl.py
+++ b/tests/test_repl.py
@@ -1,0 +1,23 @@
+import pytest
+from io import StringIO
+from unittest.mock import patch
+from promptshell.main import main  # Adjust the import based on your project structure
+import os
+
+@patch('os.get_terminal_size', return_value=os.terminal_size((80, 24)))
+@patch('builtins.input', side_effect=['exit'])
+@patch('sys.stdout', new_callable=StringIO)
+def test_exit_command(mock_stdout, mock_input, mock_terminal_size):
+    """Test that the 'exit' command terminates the REPL session."""
+    main()
+    output = mock_stdout.getvalue()
+    assert "Terminating..." in output  # Check for termination message
+
+@patch('os.get_terminal_size', return_value=os.terminal_size((80, 24)))
+@patch('builtins.input', side_effect=['quit'])
+@patch('sys.stdout', new_callable=StringIO)
+def test_quit_command(mock_stdout, mock_input, mock_terminal_size):
+    """Test that the 'quit' command terminates the REPL session."""
+    main()
+    output = mock_stdout.getvalue()
+    assert "Terminating..." in output  # Check for termination message


### PR DESCRIPTION
**Key Changes:**

- The REPL now recognizes both exit and quit as valid commands to terminate the session.
- A comment has been added to clarify the purpose of supporting both commands for future maintainers.
- Test cases have been implemented to verify that both commands function correctly without introducing any regressions.