### PR TITLE
feat: Add --version flag and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,13 +164,16 @@ $ backup all .txt files in a folder named backup
 $ !mkdir backup && copy *.txt backup\
 
 # Ask questions by prefixing or suffixing your query with '?'
-$ What’s the command to list all hidden files?
+$ What's the command to list all hidden files?
 
 # Configure or change the LLM provider
 $ --config
 
 # View help and usage instructions
 $ --help
+
+# Check the installed version
+$ --version
 
 # Clear the terminal screen
 $ clear
@@ -224,7 +227,7 @@ PromptShell is currently in **alpha stage** of development.
 
 ## 🤝 Contributing
 
-We welcome contributions! Here’s how to help:
+We welcome contributions! Here's how to help:
 
 1. Fork the repository.
 2. Create a branch: `git checkout -b feature/your-idea`.

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -5,8 +5,16 @@ import os
 from .ansi_support import enable_ansi_support
 from .format_utils import format_text, reset_format, get_terminal_size
 from .setup import setup_wizard, load_config, get_active_model
+import importlib.metadata
+
+__version__ = importlib.metadata.version("promptshell")
 
 def main():
+    # Handle --version flag
+    if len(os.sys.argv) > 1 and os.sys.argv[1] == "--version":
+        print(f"PromptShell v{__version__}")
+        return
+
     config = load_config()
     if not config:
         print("First-time setup required!")
@@ -50,7 +58,9 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
 - Start or end your input with '?' to ask a question.
 - Tab completion for files and folders is enabled.
 - Use 'Ctrl + c' or type 'quit' to quit the assistant.
-- Type 'clear' to clear the terminal.{reset_format()}""")
+- Type 'clear' to clear the terminal.
+- Use '--version' to check the installed version.
+- Type '--config' to configure settings.{reset_format()}""")
                 continue
 
             result = assistant.execute_command(user_input)

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,25 @@
+import unittest
+import sys
+import os
+
+# Add the project root to Python path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Import test modules
+from test_version import test_version_flag
+
+def run_tests():
+    print("Running PromptShell tests...")
+    
+    try:
+        test_version_flag()
+        print("\n✅ All tests passed successfully!")
+    except AssertionError as e:
+        print(f"\n❌ Test failed: {str(e)}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"\n❌ Unexpected error: {str(e)}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    run_tests() 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,51 @@
+import subprocess
+import sys
+import os
+import shutil
+
+def test_version_flag():
+    # Try to find promptshell in PATH
+    promptshell_cmd = shutil.which("promptshell")
+    
+    if not promptshell_cmd:
+        # If not in PATH, try to find it in the Python scripts directory
+        python_scripts = os.path.join(sys.prefix, "Scripts" if sys.platform == "win32" else "bin")
+        promptshell_cmd = os.path.join(python_scripts, "promptshell")
+        
+        if not os.path.exists(promptshell_cmd):
+            raise FileNotFoundError(
+                "Could not find promptshell command. Make sure you have installed the package "
+                "using 'pip install -e .' in the project root directory."
+            )
+
+    print(f"Testing with promptshell at: {promptshell_cmd}")
+
+    # Run the command with --version flag
+    try:
+        result = subprocess.run(
+            [promptshell_cmd, "--version"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+    except subprocess.CalledProcessError as e:
+        raise AssertionError(f"Command failed with error: {e.stderr}")
+
+    # Check if output matches expected format
+    output = result.stdout.strip()
+    if not output.startswith("PromptShell v"):
+        raise AssertionError(f"Unexpected output format: {output}")
+    
+    # Verify version number format (x.y.z)
+    version = output.split("v")[1]
+    version_parts = version.split(".")
+    if len(version_parts) != 3:
+        raise AssertionError(f"Invalid version format: {version}")
+    if not all(part.isdigit() for part in version_parts):
+        raise AssertionError(f"Version parts should be numbers: {version}")
+
+    print(f"Successfully verified version: {output}")
+
+if __name__ == "__main__":
+    test_version_flag()
+    print("Version flag test passed successfully!") 


### PR DESCRIPTION
This pull request addresses issue #2 by adding a --version flag to PromptShell. The flag allows users to check the current version of the tool, outputting the version number when invoked. I’ve implemented the feature as per the requirements, tested it locally to ensure it works correctly, and verified that it meets all the criteria outlined in the issue.

Please review the changes and let me know if anything needs adjustment!