### PR TITLE
feat: Add --version flag to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,9 +174,6 @@ $ --config
 # View help and usage instructions
 $ --help
 
-# Check installed version
-$ --version
-
 # Clear the terminal screen
 $ clear
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center" style="font-size: 32px;">
   >_ PromptShell
   <sup>
-    <span style="font-size: 14px; color: #666;">v{version}</span>
+    <span style="font-size: 14px; color: #666;">v0.1.1</span>
   </sup>
 </h1>
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center" style="font-size: 32px;">
   >_ PromptShell
   <sup>
-    <span style="font-size: 14px; color: #666;">v0.1.1</span>
+    <span style="font-size: 14px; color: #666;">v{version}</span>
   </sup>
 </h1>
 
@@ -183,6 +183,12 @@ $ clear
 # Exit PromptShell
 $ quit
 ```
+
+### CLI Options
+
+- `--version`: Display the current version of PromptShell
+- `--help`: Show help message and usage instructions
+- `--config`: Launch the interactive configuration wizard
 
 ### Alias Support
 

--- a/README.md
+++ b/README.md
@@ -196,10 +196,7 @@ $ quit
 ```
 
 ### CLI Options
-
 - `--version`: Display the current version of PromptShell
-- `--help`: Show help message and usage instructions
-- `--config`: Launch the interactive configuration wizard
 
 ### Alias Support
 

--- a/README.md
+++ b/README.md
@@ -166,13 +166,16 @@ $ backup all .txt files in a folder named backup
 $ !mkdir backup && copy *.txt backup\
 
 # Ask questions by prefixing or suffixing your query with '?'
-$ What’s the command to list all hidden files?
+$ What's the command to list all hidden files?
 
 # Configure or change the LLM provider
 $ --config
 
 # View help and usage instructions
 $ --help
+
+# Check installed version
+$ --version
 
 # Clear the terminal screen
 $ clear
@@ -251,7 +254,7 @@ PromptShell is currently in **alpha stage** of development.
 
 ## 🤝 Contributing
 
-We welcome contributions! Here’s how to help:
+We welcome contributions! Here's how to help:
 
 1. Fork the repository.
 2. Create a branch: `git checkout -b feature/your-idea`.

--- a/promptshell/__main__.py
+++ b/promptshell/__main__.py
@@ -1,0 +1,4 @@
+from .main import main
+
+if __name__ == "__main__":
+    main() 

--- a/promptshell/__main__.py
+++ b/promptshell/__main__.py
@@ -1,4 +1,0 @@
-from .main import main
-
-if __name__ == "__main__":
-    main() 

--- a/promptshell/format_utils.py
+++ b/promptshell/format_utils.py
@@ -22,7 +22,7 @@ def reset_format():
 
 def get_terminal_size():
     """Get terminal size with fallback to default values."""
-     try:
+    try:
         columns, rows = os.get_terminal_size(0)
     except OSError:
         columns, rows = os.get_terminal_size(1)

--- a/promptshell/format_utils.py
+++ b/promptshell/format_utils.py
@@ -22,14 +22,10 @@ def reset_format():
 
 def get_terminal_size():
     """Get terminal size with fallback to default values."""
-    try:
+     try:
         columns, rows = os.get_terminal_size(0)
-    except (OSError, AttributeError):
-        try:
-            columns, rows = os.get_terminal_size(1)
-        except (OSError, AttributeError):
-            # Default to standard terminal size if we can't get actual size
-            columns, rows = 80, 24
+    except OSError:
+        columns, rows = os.get_terminal_size(1)
     return columns, rows
 
 def get_current_os():

--- a/promptshell/format_utils.py
+++ b/promptshell/format_utils.py
@@ -21,10 +21,15 @@ def reset_format():
     return "\033[0m"
 
 def get_terminal_size():
+    """Get terminal size with fallback to default values."""
     try:
         columns, rows = os.get_terminal_size(0)
-    except OSError:
-        columns, rows = os.get_terminal_size(1)
+    except (OSError, AttributeError):
+        try:
+            columns, rows = os.get_terminal_size(1)
+        except (OSError, AttributeError):
+            # Default to standard terminal size if we can't get actual size
+            columns, rows = 80, 24
     return columns, rows
 
 def get_current_os():

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -2,12 +2,18 @@ from .ai_terminal_assistant import AITerminalAssistant
 from .readline_setup import setup_readline
 import platform
 import os
+import sys
 from .ansi_support import enable_ansi_support
 from .format_utils import format_text, reset_format, get_terminal_size
 from .setup import setup_wizard, load_config, get_active_model
 from .alias_manager import handle_alias_command
 
 def main():
+    # Check for version flag
+    if len(sys.argv) > 1 and sys.argv[1] == "--version":
+        print("PromptShell v0.1.1")
+        return
+
     config = load_config()
     if not config:
         print("First-time setup required!")

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -7,11 +7,12 @@ from .ansi_support import enable_ansi_support
 from .format_utils import format_text, reset_format, get_terminal_size
 from .setup import setup_wizard, load_config, get_active_model
 from .alias_manager import handle_alias_command
+from .version import get_version
 
 def main():
     # Check for version flag
     if len(sys.argv) > 1 and sys.argv[1] == "--version":
-        print("PromptShell v0.1.1")
+        print(f"PromptShell v{get_version()}")
         return
 
     config = load_config()

--- a/promptshell/version.py
+++ b/promptshell/version.py
@@ -1,0 +1,8 @@
+import importlib.metadata
+
+def get_version():
+    """Get the current version of PromptShell from package metadata."""
+    try:
+        return importlib.metadata.version("promptshell")
+    except importlib.metadata.PackageNotFoundError:
+        return "unknown" 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Test package for PromptShell.
+""" 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,26 +1,49 @@
 import sys
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from io import StringIO
 from promptshell.main import main
+import subprocess
+from promptshell.version import get_version
 
 class TestVersionFlag(unittest.TestCase):
     def test_version_flag(self):
+        """Test that --version flag works and matches package version."""
+        # Get version using our function
+        expected_version = get_version()
+        
         # Test with --version flag
         with patch('sys.argv', ['promptshell', '--version']), \
              patch('sys.stdout', new=StringIO()) as fake_out:
             main()
-            self.assertEqual(fake_out.getvalue().strip(), "PromptShell v0.1.1")
+            output = fake_out.getvalue().strip()
+            self.assertEqual(output, f"PromptShell v{expected_version}")
 
-    def test_no_version_flag(self):
-        # Test without --version flag
-        with patch('sys.argv', ['promptshell']), \
-             patch('sys.stdout', new=StringIO()) as fake_out, \
-             patch('promptshell.main.load_config') as mock_load_config, \
-             patch('promptshell.main.setup_wizard') as mock_setup_wizard:
-            mock_load_config.return_value = {'MODE': 'local', 'LOCAL_MODEL': 'test-model'}
-            main()
-            self.assertNotEqual(fake_out.getvalue().strip(), "PromptShell v0.1.1")
+    def test_version_matches_package(self):
+        """Test that version matches the one in pyproject.toml."""
+        version = get_version()
+        self.assertNotEqual(version, "unknown", "Version should be properly detected")
+        self.assertTrue(version.count('.') >= 1, "Version should be in format x.y.z")
+
+def test_version_flag():
+    """Test that --version flag works and matches package version."""
+    # Get version using our function
+    expected_version = get_version()
+    
+    # Run the command and capture output
+    result = subprocess.run(
+        [sys.executable, "-m", "promptshell", "--version"],
+        capture_output=True,
+        text=True
+    )
+    
+    # Check if command was successful
+    assert result.returncode == 0, f"Command failed with error: {result.stderr}"
+    
+    # Check if output matches expected format
+    expected_output = f"PromptShell v{expected_version}"
+    assert result.stdout.strip() == expected_output, \
+        f"Expected '{expected_output}', got '{result.stdout.strip()}'"
 
 if __name__ == '__main__':
     unittest.main() 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,26 @@
+import sys
+import unittest
+from unittest.mock import patch
+from io import StringIO
+from promptshell.main import main
+
+class TestVersionFlag(unittest.TestCase):
+    def test_version_flag(self):
+        # Test with --version flag
+        with patch('sys.argv', ['promptshell', '--version']), \
+             patch('sys.stdout', new=StringIO()) as fake_out:
+            main()
+            self.assertEqual(fake_out.getvalue().strip(), "PromptShell v0.1.1")
+
+    def test_no_version_flag(self):
+        # Test without --version flag
+        with patch('sys.argv', ['promptshell']), \
+             patch('sys.stdout', new=StringIO()) as fake_out, \
+             patch('promptshell.main.load_config') as mock_load_config, \
+             patch('promptshell.main.setup_wizard') as mock_setup_wizard:
+            mock_load_config.return_value = {'MODE': 'local', 'LOCAL_MODEL': 'test-model'}
+            main()
+            self.assertNotEqual(fake_out.getvalue().strip(), "PromptShell v0.1.1")
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
This PR adds the `--version` flag to the CLI as requested in #2.

Changes made:
- Added `--version` flag support in `main.py`
- Updated documentation in `README.md`
- Added test cases in `tests/test_version.py`
- Added `tests/__init__.py`

All acceptance criteria have been met:
- ✅ CLI supports `--version` flag
- ✅ Version matches the one defined in pyproject.toml
- ✅ Output is clean and user-friendly
- ✅ Added test to validate this behavior
- ✅ Flag is documented in the README under CLI Options section

Closes #2