### PR TITLE
Feature/improved dangerous command safeguard

### DIFF
--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -53,6 +53,13 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
 - Type 'clear' to clear the terminal.{reset_format()}""")
                 continue
 
+            # ✅ Handle alias command
+            if user_input.lower().startswith("alias "):
+                result = handle_alias_command(user_input, assistant.alias_manager)
+                print(result)
+                continue
+
+            # All other commands (including dangerous ones) are handled by the assistant
             result = assistant.execute_command(user_input)
             print(result)
 


### PR DESCRIPTION
Hey @Kirti-Rathi ,

I've implemented all the required changes as discussed:

✅ The manual safeguard now includes an additional confirmation step:
After the user confirms execution of a dangerous command, they’re also required to retype the exact command as a second-layer verification.

✅ This ensures the user’s input doesn't rely on simply typing CONFIRM, and adds stronger protection before execution.

✅ Try running a dangerous command like: delete spare_file.txt — you’ll now see both confirmation prompts working as intended.

✅ The main logic for this is updated in ai_terminal_assistant.py.

🔄 Also made sure my branch is up-to-date with main.

Let me know if anything else needs refining!