### PR TITLE
⚠️(Bug Fix)  [#54]Direct Command Executions fail and [#71]Application failed to Start

### DIFF
--- a/promptshell/ai_terminal_assistant.py
+++ b/promptshell/ai_terminal_assistant.py
@@ -252,7 +252,8 @@ class AITerminalAssistant:
                     os.system('clear')
                 return ""
             if user_input.startswith('!'):
-                expanded = self.alias_manager.expand_alias(user_input[1:])
+                user_input = "!cd .." if user_input[1:].strip() == "cd.." else user_input # generally cd.. works but 'cd ..' is the right syntax
+                expanded = self.alias_manager.expand_alias(user_input[1:].strip())
                 if expanded != user_input[1:]:
                     print(f"Expanded to: {expanded}")
                 return self.run_direct_command(expanded)

--- a/promptshell/alias_manager.py
+++ b/promptshell/alias_manager.py
@@ -75,13 +75,13 @@ class AliasManager:
         """
 
         if not self.validate_alias_name(name):
-            return False, f"{format_text("red")}Invalid alias name: Name must be alphanumeric with underscores{reset_format()}"
+            return False, f"{format_text('red')}Invalid alias name: Name must be alphanumeric with underscores{reset_format()}"
         
         if not self.validate_command(command):
-            return False, f"{format_text("red", bold=True)}Invalid Command: Contains dangerous patterns{reset_format()}"
+            return False, f"{format_text('red', bold=True)}Invalid Command: Contains dangerous patterns{reset_format()}"
         
         if name in self.aliases:
-            return False, f"{format_text("red")}Duplicate alias name: Alias already exists{reset_format()}"
+            return False, f"{format_text('red')}Duplicate alias name: Alias already exists{reset_format()}"
         
         self.aliases[name] = {
             'command': command,
@@ -103,7 +103,7 @@ class AliasManager:
         """
 
         if name not in self.aliases:
-            return False, f"{format_text("red")}Alias not found{reset_format()}"
+            return False, f"{format_text('red')}Alias not found{reset_format()}"
         
         del self.aliases[name]
         self.save_aliases()
@@ -139,7 +139,7 @@ class AliasManager:
         path_obj = Path(file_path)
 
         if not path_obj.exists() or not path_obj.is_file():
-            return False, f"{format_text("red")}Import error: File '{file_path}' not found.{reset_format()}"
+            return False, f"{format_text('red')}Import error: File '{file_path}' not found.{reset_format()}"
 
         try:
             with open(path_obj, 'r') as f:
@@ -150,9 +150,9 @@ class AliasManager:
             self.save_aliases()
             return True, "Aliases imported successfully"
         except json.JSONDecodeError:
-            return False, f"{format_text("red")}Invalid JSON: Incorrect JSON format in alias file{reset_format()}."
+            return False, f"{format_text('red')}Invalid JSON: Incorrect JSON format in alias file{reset_format()}."
         except Exception as e:
-            return False, f"{format_text("red")}Import error: Failed to import aliases: {str(e)}{reset_format()}"
+            return False, f"{format_text('red')}Import error: Failed to import aliases: {str(e)}{reset_format()}"
 
     
     
@@ -171,7 +171,7 @@ class AliasManager:
                 json.dump({'aliases': self.aliases}, f, indent=2)
             return True, "Aliases exported successfully"
         except Exception as e:
-            return False, f"{format_text("red")}Export failed: {str(e)}{reset_format()}"
+            return False, f"{format_text('red')}Export failed: {str(e)}{reset_format()}"
     
     def expand_alias(self, input_command):
         """Expands aliases in commands.
@@ -228,7 +228,7 @@ def handle_alias_command(command: str, alias_manager: AliasManager) -> str:
     try:
         parts = shlex.split(command)
         if len(parts) < 2:
-            return f"{format_text("white", bold=True)}Usage: alias [add|remove|list|import|export|help]{reset_format()}"
+            return f"{format_text('white', bold=True)}Usage: alias [add|remove|list|import|export|help]{reset_format()}"
         
         subcommand = parts[1].lower()
         
@@ -250,7 +250,7 @@ def handle_alias_command(command: str, alias_manager: AliasManager) -> str:
                 alias = alias_manager.list_aliases(parts[2])
                 if alias:
                     return f"{parts[2]}: {alias['command']}\nDescription: {alias.get('description', '')}"
-                return f"{format_text("red")}Invalid alias name: Alias not found{reset_format()}"
+                return f"{format_text('red')}Invalid alias name: Alias not found{reset_format()}"
             aliases = alias_manager.list_aliases()
             return "\n".join([f"{name}: {data['command']}" for name, data in aliases.items()])
         
@@ -274,6 +274,6 @@ def handle_alias_command(command: str, alias_manager: AliasManager) -> str:
                 "  alias clear - Clear all aliases"
             )
         
-        return f"{format_text("red")}Invalid alias command: Use alias help for valid all commands{reset_format()}"
+        return f"{format_text('red')}Invalid alias command: Use alias help for valid all commands{reset_format()}"
     except Exception as e:
-        return f"{format_text("red")}Error processing alias command: {str(e)}{reset_format()}"
+        return f"{format_text('red')}Error processing alias command: {str(e)}{reset_format()}"

--- a/promptshell/spinner_progress_utils.py
+++ b/promptshell/spinner_progress_utils.py
@@ -1,7 +1,7 @@
 """
 Spinner an Progress Bar Utilities for PromptShell
 -------------------------------------------------
-from .spinner_progess_utils import spinner, progress_bar
+from .spinner_progress_utils import spinner, progress_bar
 
 This module provides decorators for adding loading indicators to functions.
 


### PR DESCRIPTION
# Issue #54  **_SOLVED_**
### The main issue was the system getting confused with spaces introduced in the input command.

## Solution
### Strip the input string to remove that extra space form both the sides.
![image](https://github.com/user-attachments/assets/8b86ce48-2262-4ba8-9950-601ee415f6b7)

Also, usually `cd..` works fine in normal terminal or shell, but its actually `cd ..` . Just added a check to auto rectify that.
![image](https://github.com/user-attachments/assets/0b0d6ed1-1d6c-46aa-aea4-05e773846b4f)


---
# Issue #72  _**SOLVED**_
## ‼️The issue:⚠️
![image](https://github.com/user-attachments/assets/f9f61bc1-4d50-44a8-b6f8-351beb8ea55b)

## 💡The reason:
### Multiple **double quotes ( " " )**  were used within a single f-"String" confusing the system and preventing application start.

## ✅After quick fix:

![image](https://github.com/user-attachments/assets/a8db5263-3562-412c-b51e-81745c2633f8)

