### PR TITLE
feat: Add --history command to show last 10 commands in REPL

### DIFF
--- a/promptshell/ai_terminal_assistant.py
+++ b/promptshell/ai_terminal_assistant.py
@@ -261,10 +261,10 @@ class AITerminalAssistant:
                 append_history(user_input, expanded)
                 return self.run_direct_command(expanded)
             if user_input.lower() == "--history":
-                history = get_last_n_history(10)
+                history = get_last_n_history()
                 lines = []
                 lines.append("PromptShell Command History")
-                lines.append("\u2500" * 44)
+                lines.append("\u2500" * 44 if platform.system().lower() != "windows" else "-" * 44)
                 for idx, entry in enumerate(history, 1):
                     ts = entry["timestamp"].replace("T", " ")
                     lines.append(f"[{idx}] {ts}")
@@ -308,6 +308,9 @@ class AITerminalAssistant:
                     command = command[9:]
                 formatted_command = format_text('cyan') + f"Command: {command}" + reset_format()
                 print(formatted_command)
+                self.command_history.append(command)
+                if len(self.command_history) > 10:
+                    self.command_history.pop(0)
                 append_history(user_input, command)
                 if command.startswith("cd "):
                     path = command.split(" ", 1)[1]
@@ -341,6 +344,9 @@ class AITerminalAssistant:
         try:
             formatted_command = format_text('cyan') + f"Direct Command: {command}" + reset_format()
             print(formatted_command)
+            self.command_history.append(command)
+            if len(self.command_history) > 10:
+                self.command_history.pop(0)
             if command.startswith("cd "):
                 path = command.split(" ", 1)[1]
                 os.chdir(os.path.expanduser(path))

--- a/promptshell/ai_terminal_assistant.py
+++ b/promptshell/ai_terminal_assistant.py
@@ -459,3 +459,6 @@ class AITerminalAssistant:
         print(format_text('yellow') + "\nFor safety, please re-type or paste the exact command to proceed:" + reset_format())
         user_input = input("> ").strip()
         return user_input == command
+    def get_history(self):
+        """Return the last 10 commands entered in this session."""
+        return self.command_history[-10:]

--- a/promptshell/ai_terminal_assistant.py
+++ b/promptshell/ai_terminal_assistant.py
@@ -11,6 +11,8 @@ from .data_gatherer import DataGatherer
 from .format_utils import format_text, reset_format, get_current_os, get_os_specific_examples
 from .system_info import get_system_info
 from .alias_manager import AliasManager
+from .history_manager import append_history, get_last_n_history
+import shutil
 
 class AITerminalAssistant:
     def __init__(self, model_name: str, max_tokens: int = 8000, config: dict = None):
@@ -256,7 +258,29 @@ class AITerminalAssistant:
                 expanded = self.alias_manager.expand_alias(user_input[1:].strip())
                 if expanded != user_input[1:]:
                     print(f"Expanded to: {expanded}")
+                append_history(user_input, expanded)
                 return self.run_direct_command(expanded)
+            if user_input.lower() == "--history":
+                history = get_last_n_history(10)
+                lines = []
+                lines.append("PromptShell Command History")
+                lines.append("\u2500" * 44)
+                for idx, entry in enumerate(history, 1):
+                    ts = entry["timestamp"].replace("T", " ")
+                    lines.append(f"[{idx}] {ts}")
+                    lines.append(f"    Input:      {entry['natural_language']}")
+                    lines.append(f"    Translated:   {entry['shell_command']}\n")
+                output = "\n".join(lines)
+                # Paginate if >30 lines
+                if len(lines) > 30:
+                    pager = os.environ.get("PAGER")
+                    if not pager:
+                        pager = "less -R" if platform.system().lower() != "windows" else "more"
+                    proc = subprocess.Popen(pager, shell=True, stdin=subprocess.PIPE)
+                    proc.communicate(output.encode("utf-8"))
+                else:
+                    print(output)
+                return ""
             additional_data = self.gather_additional_data(user_input)
             command = self.command_executor(f"""
             User Input: {user_input}
@@ -284,9 +308,7 @@ class AITerminalAssistant:
                     command = command[9:]
                 formatted_command = format_text('cyan') + f"Command: {command}" + reset_format()
                 print(formatted_command)
-                self.command_history.append(command)
-                if len(self.command_history) > 10:
-                    self.command_history.pop(0)
+                append_history(user_input, command)
                 if command.startswith("cd "):
                     path = command.split(" ", 1)[1]
                     os.chdir(os.path.expanduser(path))
@@ -319,9 +341,6 @@ class AITerminalAssistant:
         try:
             formatted_command = format_text('cyan') + f"Direct Command: {command}" + reset_format()
             print(formatted_command)
-            self.command_history.append(command)
-            if len(self.command_history) > 10:
-                self.command_history.pop(0)
             if command.startswith("cd "):
                 path = command.split(" ", 1)[1]
                 os.chdir(os.path.expanduser(path))
@@ -459,6 +478,4 @@ class AITerminalAssistant:
         print(format_text('yellow') + "\nFor safety, please re-type or paste the exact command to proceed:" + reset_format())
         user_input = input("> ").strip()
         return user_input == command
-    def get_history(self):
-        """Return the last 10 commands entered in this session."""
-        return self.command_history[-10:]
+

--- a/promptshell/history_manager.py
+++ b/promptshell/history_manager.py
@@ -1,0 +1,42 @@
+import os
+import json
+from datetime import datetime
+from .setup import CONFIG_DIR
+
+HISTORY_FILE = os.path.join(CONFIG_DIR, "history.jsonl")
+MAX_HISTORY = 100
+
+def append_history(natural_language, shell_command):
+    """Append a new entry to the history file, keeping only the last 100 entries."""
+    entry = {
+        "timestamp": datetime.now().isoformat(timespec="seconds"),
+        "natural_language": natural_language,
+        "shell_command": shell_command
+    }
+    history = []
+    if os.path.exists(HISTORY_FILE):
+        with open(HISTORY_FILE, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    history.append(json.loads(line))
+                except Exception:
+                    continue
+    history.append(entry)
+    # Keep only the last MAX_HISTORY entries
+    history = history[-MAX_HISTORY:]
+    with open(HISTORY_FILE, "w", encoding="utf-8") as f:
+        for item in history:
+            f.write(json.dumps(item) + "\n")
+
+def get_last_n_history(n=10):
+    """Return the last n entries from the history file (most recent last)."""
+    if not os.path.exists(HISTORY_FILE):
+        return []
+    history = []
+    with open(HISTORY_FILE, "r", encoding="utf-8") as f:
+        for line in f:
+            try:
+                history.append(json.loads(line))
+            except Exception:
+                continue
+    return history[-n:] if n > 0 else history 

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -94,4 +94,4 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
             break
 
 if __name__ == "__main__":
-     main()
+      main()

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -94,5 +94,4 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
             break
 
 if __name__ == "__main__":
-    
-    main()
+     main()

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -93,15 +93,5 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
             print(format_text('red', bold=True) + "\nTerminating..." + reset_format())
             break
 
-        if user_input.lower() == "--history":
-          history = assistant.get_history()
-          if not history:
-           print("No command history yet.")
-        else:
-          print("Last 10 commands:")
-          for i, cmd in enumerate(history, 1):
-              print(f"{i}: {cmd}")
-          continue
-
 if __name__ == "__main__":
     main()

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -93,5 +93,15 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
             print(format_text('red', bold=True) + "\nTerminating..." + reset_format())
             break
 
+        if user_input.lower() == "--history":
+          history = assistant.get_history()
+          if not history:
+           print("No command history yet.")
+        else:
+          print("Last 10 commands:")
+          for i, cmd in enumerate(history, 1):
+              print(f"{i}: {cmd}")
+          continue
+
 if __name__ == "__main__":
     main()

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -94,4 +94,4 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
             break
 
 if __name__ == "__main__":
-   main()
+    main()

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -94,4 +94,4 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
             break
 
 if __name__ == "__main__":
-      main()
+   main()

--- a/promptshell/main.py
+++ b/promptshell/main.py
@@ -94,4 +94,5 @@ Type '--help' for assistance and '--config' for settings.{reset_format()}""")
             break
 
 if __name__ == "__main__":
+    
     main()


### PR DESCRIPTION
This PR adds a --history command to the PromptShell REPL.
Users can type --history to view the last 10 commands entered in the current session.
This improves usability by making it easy to recall and reuse previous commands.
Usage:
Enter a few commands (e.g., ls, pwd, echo Hello).
Type --history to see your last 10 commands.